### PR TITLE
Adding support for AborFirmaCraft (AFC)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs = -Xmx3G
 org.gradle.daemon = false
 
 # mod version info
-mod_version = 1.17.11
+mod_version = 1.17.12
 mod_id = selene
 maven_group = net.mehvahdjukaar
 

--- a/src/main/java/net/mehvahdjukaar/selene/block_set/BlockType.java
+++ b/src/main/java/net/mehvahdjukaar/selene/block_set/BlockType.java
@@ -90,10 +90,10 @@ public abstract class   BlockType {
         String post = postpend.isEmpty() ? "" : "_" + postpend;
         var id = this.getId();
         ResourceLocation[] targets = {
-                // Unqiue ID: tfc:wood/planks/<TYPE>_append
-            new ResourceLocation(id.getNamespace(), "wood/planks/" + id.getPath() + "_" + append), //Support TFC
-                // TFC's twig only: tfc:wood/twig/<TYPE>, Similar to "stick"
-            new ResourceLocation(id.getNamespace(), "wood/" + append + "/" + id.getPath()), //Support TFC
+                // MODname:wood/planks/<woodTYPE>_append to include children of wood_type
+            new ResourceLocation(id.getNamespace(), "wood/planks/" + id.getPath() + "_" + append), //Support TFC & AFC
+                // TFC's twig only: MODname:wood/twig/<woodTYPEe>, Similar to "stick"
+            new ResourceLocation(id.getNamespace(), "wood/" + append + "/" + id.getPath()), //Support TFC & AFC
             new ResourceLocation(id.getNamespace(), id.getPath() + "_" + append + post),
             new ResourceLocation(id.getNamespace(), append + "_" + id.getPath() + post),
             new ResourceLocation(id.getNamespace(), id.getPath() + "_planks_" + append + post),

--- a/src/main/java/net/mehvahdjukaar/selene/block_set/wood/WoodType.java
+++ b/src/main/java/net/mehvahdjukaar/selene/block_set/wood/WoodType.java
@@ -64,8 +64,8 @@ public class WoodType extends IBlockType {
         var id = this.getId();
         String log = this.log.getRegistryName().getPath();
         ResourceLocation[] targets = {
-                // Unique ID: tfc:wood/stripped_log/<TYPE>
-                new ResourceLocation(id.getNamespace(), "wood/" + append + post + "/" + id.getPath()), //Support TFC
+                // MOD_NAME:wood/stripped_log/<WoodType> to include stripped_log
+                new ResourceLocation(id.getNamespace(), "wood/" + append + post + "/" + id.getPath()), //Support TFC & AFC
                 new ResourceLocation(id.getNamespace(), log + "_" + append + post),
                 new ResourceLocation(id.getNamespace(), append + "_" + log + post),
                 new ResourceLocation(id.getNamespace(), id.getPath() + "_" + append + post),
@@ -161,7 +161,7 @@ public class WoodType extends IBlockType {
         this.addChild("pressure_plate", pressurePlate);
         this.addChild("sign", signItem.get());
         this.addChild("boat", boatItem.get());
-        this.addChild("stick", twig); // TFC only
+        this.addChild("stick", twig); // TFC & AFC only
 
     }
 

--- a/src/main/java/net/mehvahdjukaar/selene/block_set/wood/WoodTypeRegistry.java
+++ b/src/main/java/net/mehvahdjukaar/selene/block_set/wood/WoodTypeRegistry.java
@@ -35,6 +35,10 @@ public class WoodTypeRegistry extends BlockTypeRegistry<WoodType> {
         INSTANCE = this;
     }
 
+    public static @Nullable WoodType getValue(ResourceLocation name) {
+        return (WoodType)INSTANCE.get(name);
+    }
+
     public static WoodType fromNBT(String name) {
         return WOOD_TYPES.getOrDefault(new ResourceLocation(name), WoodType.OAK_WOOD_TYPE);
     }
@@ -67,12 +71,12 @@ public class WoodTypeRegistry extends BlockTypeRegistry<WoodType> {
         ResourceLocation baseRes = baseBlock.getRegistryName();
         String name = null;
         String path = baseRes.getPath();
-        // Support TFC aka TerraFirmaCraft
-        if(baseRes.getNamespace().equals("tfc")){
+        // Support TerraFirmaCraft (TFC) && ArborFirmaCraft (AFC)
+        if(baseRes.getNamespace().equals("tfc") || baseRes.getNamespace().equals("afc")) {
             //needs to contain planks in its name
             if(path.contains("wood/planks/")){
                 var log = Registry.BLOCK.getOptional(
-                        new ResourceLocation(baseRes.getNamespace(),path.replace("planks","log")));
+                        new ResourceLocation(baseRes.getNamespace(), path.replace("planks","log")));
                 if(log.isPresent()){
                     ResourceLocation id = new ResourceLocation(baseRes.getNamespace(), path.replace("wood/planks/",""));
                     return Optional.of(new WoodType(id, baseBlock, log.get()));
@@ -80,6 +84,7 @@ public class WoodTypeRegistry extends BlockTypeRegistry<WoodType> {
             }
             return Optional.empty();
         }
+        // DEFAULT
         if (path.endsWith("_planks")) {
             name = path.substring(0, path.length() - "_planks".length());
         } else if (path.startsWith("planks_")) {


### PR DESCRIPTION
- WoodTypeRegistry: ported `WoodType getValue()` from 1.19.2 (useful for modules ported from 1.19.2)
- gradle.properties: Updated 1.7.11 to 1.7.12

@MehVahdJukaar, let me know if there are any issues. 