### PR TITLE
[1.20] Add Boats with Chests as child items to wood types

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/set/wood/WoodType.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/set/wood/WoodType.java
@@ -140,6 +140,7 @@ public class WoodType extends BlockType {
     @Override
     public void initializeChildrenItems() {
         this.addChild("boat", this.findRelatedEntry("boat", BuiltInRegistries.ITEM));
+        this.addChild("chest_boat", this.findRelatedEntry("chest_boat", BuiltInRegistries.ITEM));
     }
 
     public static class Finder implements SetFinder<WoodType> {


### PR DESCRIPTION
This PR adds Boats with Chests as items that are detected by `WoodType`s, bringing them in line with regular boats.

This PR targets the 1.20 branch of Moonlight; if accepted here, I'll make corresponding PRs of this change for Moonlight's 1.19 branches so Wood Good can benefit from it.