### PR TITLE
[1.19.2] Add Boats with Chests as child items to wood types

### DIFF
--- a/src/main/java/net/mehvahdjukaar/moonlight/block_set/wood/WoodType.java
+++ b/src/main/java/net/mehvahdjukaar/moonlight/block_set/wood/WoodType.java
@@ -115,6 +115,7 @@ public class WoodType extends BlockType {
         this.addChild("button", this.findRelatedEntry("button", ForgeRegistries.BLOCKS));
         this.addChild("pressure_plate", this.findRelatedEntry("pressure_plate", ForgeRegistries.BLOCKS));
         this.addChild("boat", this.findRelatedEntry("boat", ForgeRegistries.ITEMS));
+        this.addChild("chest_boat", this.findRelatedEntry("chest_boat", ForgeRegistries.ITEMS));
         this.addChild("sign", this.findRelatedEntry("sign", ForgeRegistries.ITEMS));
     }
 


### PR DESCRIPTION
Backport of #129 to the `1.19` branch.