### PR TITLE
[1.19.3] Add Boats with Chests as child items to wood types

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/set/wood/WoodType.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/set/wood/WoodType.java
@@ -127,6 +127,7 @@ public class WoodType extends BlockType {
     @Override
     public void initializeChildrenItems() {
         this.addChild("boat",(Object) this.findRelatedEntry("boat", BuiltInRegistries.ITEM));
+        this.addChild("chest_boat",(Object) this.findRelatedEntry("chest_boat", BuiltInRegistries.ITEM));
         this.addChild("sign",(Object) this.findRelatedEntry("sign", BuiltInRegistries.ITEM));
     }
 


### PR DESCRIPTION
Backport of #129 to the `1.19.3` branch.