### PR TITLE
[1.19.4] Add Boats with Chests as child items to wood types

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/set/wood/WoodType.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/set/wood/WoodType.java
@@ -137,6 +137,7 @@ public class WoodType extends BlockType {
     @Override
     public void initializeChildrenItems() {
         this.addChild("boat", this.findRelatedEntry("boat", BuiltInRegistries.ITEM));
+        this.addChild("chest_boat", this.findRelatedEntry("chest_boat", BuiltInRegistries.ITEM));
         this.addChild("sign", this.findRelatedEntry("sign", BuiltInRegistries.ITEM));
     }
 


### PR DESCRIPTION
Backport of #129 to the `1.19.4` branch.