### PR TITLE
[1.19.3] Fix NPE in `getRootResource()` when resource is not present

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/resources/pack/DynamicResourcePack.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/resources/pack/DynamicResourcePack.java
@@ -146,7 +146,8 @@ public abstract class DynamicResourcePack implements PackResources {
     @Override
     public IoSupplier<InputStream> getRootResource(String... strings) {
         String fileName = String.join("/", strings);
-        return () -> new ByteArrayInputStream(this.rootResources.get(fileName));
+        byte[] resource = this.rootResources.get(fileName);
+        return resource == null ? null : () -> new ByteArrayInputStream(resource);
     }
 
 


### PR DESCRIPTION
Currently, a call to `DynamicResourcePack#getRootResource()` with the name of a resource that is not present throws a `NullPointerException` in the `ByteArrayInputStream` constructor, crashing the game. This PR adds a null check to avoid calling the `ByteArrayInputStream` constructor when the resource is `null`. `getRootResource()` is `@Nullable`, so it is safe to return `null` from this method when the resource is not present.

Please see MoreMcmeta/core#35 for logs and a stacktrace.