### PR TITLE
[1.18] Fix NPE in `getRootResource()` when resource is not present

### DIFF
--- a/src/main/java/net/mehvahdjukaar/selene/resourcepack/DynamicResourcePack.java
+++ b/src/main/java/net/mehvahdjukaar/selene/resourcepack/DynamicResourcePack.java
@@ -149,7 +149,8 @@ public abstract class DynamicResourcePack implements PackResources {
     @Nullable
     @Override
     public InputStream getRootResource(String pFileName) {
-        return new ByteArrayInputStream(this.rootResources.get(pFileName));
+        byte[] resource = this.rootResources.get(pFileName);
+        return resource == null ? null : new ByteArrayInputStream(resource);
     }
 
     @Override


### PR DESCRIPTION
Currently, a call to `DynamicResourcePack#getRootResource()` with the name of a resource that is not present throws a `NullPointerException` in the `ByteArrayInputStream` constructor, crashing the game. This PR adds a null check to avoid calling the `ByteArrayInputStream` constructor when the resource is `null`. `getRootResource()` is `@Nullable`, so it is safe to return `null` from this method when the resource is not present.

Please see MoreMcmeta/core#35 for logs and a stacktrace.