### PR TITLE
Fixed a typo/mistake in WoodType.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ subprojects {
             project {
                 id = rootProject.project_id
                 changelog = changelogText
+                changelogType = 'markdown'
                 releaseType = 'release'
                 addGameVersion rootProject.minecraft_version
                 addGameVersion modLoader.capitalize()

--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,5 @@
-somesafety checks
+#### UPDATED:
+- Fixed a typo 
+
+#### FORGE ONLY:
+- Added support for TerraFirmaCraft & AborFirmaCraft (v2.8.63)

--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/set/wood/WoodType.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/set/wood/WoodType.java
@@ -56,7 +56,7 @@ public class WoodType extends BlockType {
         if (this.id.getNamespace().equals("tfc") || this.id.getNamespace().equals("afc")) {
             var o = BuiltInRegistries.BLOCK.getOptional(
                     new ResourceLocation(id.getNamespace(),
-                            "wood/" + append + postpend + "/" + id.getPath()));
+                            "wood/" + append + post + "/" + id.getPath()));
             if (o.isPresent()) return o.get();
         }
 

--- a/forge/update.json
+++ b/forge/update.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://www.curseforge.com/minecraft/mc-mods/selene",
   "promos": {
-    "1.19.2-latest": "1.20-2.8.63",
-    "1.19.2-recommended": "1.20-2.8.63"
+    "1.19.2-latest": "1.20-2.8.64",
+    "1.19.2-recommended": "1.20-2.8.64"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ minecraft_version = 1.20.1
 enabled_platforms = fabric,forge
 
 mod_id = moonlight
-mod_version = 1.20-2.8.63
+mod_version = 1.20-2.8.64
 maven_group = net.mehvahdjukaar
 project_id = 499980
 


### PR DESCRIPTION
#### UPDATED: 
- WoodType.java - Replaced `postpend` with `post`, so stripped_log is included. 
- gradle.properties - v2.8.64
- build.gradle - added `changelogType = 'markdown'`, this way **markdown** is set instead of **plaintext**
