### PR TITLE
Link more variant leaves to their base log

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/integration/CompatWoodTypes.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/integration/CompatWoodTypes.java
@@ -1,5 +1,6 @@
 package net.mehvahdjukaar.moonlight.api.integration;
 
+import net.mehvahdjukaar.moonlight.api.platform.PlatHelper;
 import net.mehvahdjukaar.moonlight.api.set.BlockSetAPI;
 import net.mehvahdjukaar.moonlight.api.set.leaves.LeavesType;
 import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
@@ -492,6 +493,65 @@ public class CompatWoodTypes {
                 "chipped", "red_spruce", "red_spruce_leaves", "spruce"));
         BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
                 "chipped", "white_flower_spruce", "white_flower_spruce_leaves", "spruce"));
+
+        // AETHER
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether", "golden_oak", "golden_oak_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether", "holiday", "holiday_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether", "decorated_holiday", "decorated_holiday_leaves", "aether:skyroot"));
+
+
+        String crystalLeavesWoodType = "aether:skyroot";
+        // Aether Redux replaces the skyroot logs in crystal trees with their own crystal logs
+        if (PlatHelper.isModLoaded("aether_redux")){
+            crystalLeavesWoodType = "aether_redux:crystal";
+        }
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether", "crystal", "crystal_leaves", crystalLeavesWoodType));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether", "crystal_fruit", "crystal_fruit_leaves", crystalLeavesWoodType));
+
+        // AETHER REDUX
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether_redux", "fieldsproot", "fieldsproot_leaves", "aether_redux:fieldsproot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether_redux", "gilded_oak", "gilded_oak_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether_redux", "blighted_skyroot", "blighted_skyroot_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether_redux", "purple_glacia", "purple_glacia_leaves", "aether_redux:glacia"));
+
+        // DEEP AETHER
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "deep_aether", "flowering_roseroot", "flowering_roseroot_leaves", "deep_aether:roseroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "deep_aether", "blue_roseroot", "blue_roseroot_leaves", "deep_aether:roseroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "deep_aether", "flowering_blue_roseroot", "flowering_blue_roseroot_leaves", "deep_aether:roseroot"));
+
+        // ANCIENT AETHER
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "ancient_aether", "crystal_skyroot", "crystal_skyroot_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "ancient_aether", "enchanted_skyroot", "enchanted_skyroot_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "ancient_aether", "skyroot_pine", "skyroot_pine_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "ancient_aether", "blue_skyroot_pine", "crystal_skyroot_leaves", "aether:skyroot"));
+
+        // AUTUMNITY
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "autumnity", "yellow_maple", "yellow_maple_leaves", "autumnity:maple"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "autumnity", "orange_maple", "orange_maple_leaves", "autumnity:maple"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "autumnity", "red_maple", "red_maple_leaves", "autumnity:maple"));
+
+        // ALEXSCAVES
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "alexscaves", "ancient", "ancient_leaves", "jungle"));
     }
 
     /*


### PR DESCRIPTION
### Issues Fixed
- Aether Redux's Fieldsproot Leaves weren't getting detected (they don't extend LeavesBlock)
- Variant (example: deep_aether:roseroot_leaves vs deep_aether:flowering_roseroot_leaves) leaves for several mods were using the default oak woodtype when creating recipes/models.
- Alex's Caves ancient leaves used default oak woodtype (should use jungle)

As Aether Redux replaces the skyroot logs in crystal trees with their own crystal logs, I have the choice of woodtype for the crystal leaves depend on that. 

Some comparisons, look at the colors of the logs in the hedges:
Before: 
![2024-12-22_19 54 56](https://github.com/user-attachments/assets/cd6f1c33-0f1d-4793-a474-b2641e889eb5)

After (with aether_redux, look at the top left blue hedges):
![2024-12-22_20 02 29](https://github.com/user-attachments/assets/93228cb6-59a5-4e56-befb-e6093365c5f9)

After (without aether_redux):
![2024-12-22_20 16 53](https://github.com/user-attachments/assets/4b10b16e-520b-405c-a580-d51fb38cde3f)


(The very bottom right hedge getting registered is actually dependent on a everycomp pr, but this pr will work for non-quark modules that use the leaves /w their logs to make something and so is not dependent on that pr)