### PR TITLE
Link yet more variant leaves to their base log

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/integration/CompatWoodTypes.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/integration/CompatWoodTypes.java
@@ -552,6 +552,20 @@ public class CompatWoodTypes {
         // ALEXSCAVES
         BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
                 "alexscaves", "ancient", "ancient_leaves", "jungle"));
+
+        // ENVIRONMENTAL
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "environmental", "cheerful_plum", "cheerful_plum_leaves", "environmental:plum"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "environmental", "moody_plum", "moody_plum_leaves", "environmental:plum"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "environmental", "pink_wisteria", "pink_wisteria_leaves", "environmental:wisteria"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "environmental", "blue_wisteria", "blue_wisteria_leaves", "environmental:wisteria"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "environmental", "purple_wisteria", "purple_wisteria_leaves", "environmental:wisteria"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "environmental", "white_wisteria", "white_wisteria_leaves", "environmental:wisteria")); 
     }
 
     /*

--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/integration/CompatWoodTypes.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/integration/CompatWoodTypes.java
@@ -538,6 +538,8 @@ public class CompatWoodTypes {
                 "ancient_aether", "enchanted_skyroot", "enchanted_skyroot_leaves", "aether:skyroot"));
         BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
                 "ancient_aether", "skyroot_pine", "skyroot_pine_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "ancient_aether", "blue_skyroot_pine", "blue_skyroot_pine_leaves", "aether:skyroot"));
 
         // AUTUMNITY
         BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(

--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/integration/CompatWoodTypes.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/integration/CompatWoodTypes.java
@@ -541,6 +541,16 @@ public class CompatWoodTypes {
         BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
                 "ancient_aether", "blue_skyroot_pine", "blue_skyroot_pine_leaves", "aether:skyroot"));
 
+        // AETHER GENESIS
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether_genesis", "blue_skyroot", "blue_skyroot_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether_genesis", "dark_blue_skyroot", "dark_blue_skyroot_leaves", "aether:skyroot"));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether_genesis", "purple_crystal", "purple_crystal_leaves", crystalLeavesWoodType));
+        BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
+                "aether_genesis", "purple_crystal_fruit", "purple_crystal_fruit_leaves", crystalLeavesWoodType));
+
         // AUTUMNITY
         BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
                 "autumnity", "yellow_maple", "yellow_maple_leaves", "autumnity:maple"));
@@ -565,7 +575,7 @@ public class CompatWoodTypes {
         BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
                 "environmental", "purple_wisteria", "purple_wisteria_leaves", "environmental:wisteria"));
         BlockSetAPI.addBlockTypeFinder(LeavesType.class, LeavesType.Finder.simple(
-                "environmental", "white_wisteria", "white_wisteria_leaves", "environmental:wisteria")); 
+                "environmental", "white_wisteria", "white_wisteria_leaves", "environmental:wisteria"));
     }
 
     /*


### PR DESCRIPTION
### Issues Fixed
- Re-adds and fixes the "duplicated" leavestype removed in 617321025733ffd28ebe3c160bc86e78e545ea48. The leaves do exist (but only show up when Aether Genesis is installed), but I seemingly forgot to rename the leaves block it searched for when linking it to the correct woodtype in #286.
- Several variant leaves for Environmental and Aether Genesis were not linked to the base log.

Again, Aether Redux replaces some logs with their own, so those depend on it being installed.
Comparison, look at the wood posts in the hedges:

Before:
![2025-01-10_19 46 17](https://github.com/user-attachments/assets/8441fd1f-2f9d-4c39-91eb-4e348e48f6d8)

After:
![2025-01-10_19 24 19](https://github.com/user-attachments/assets/37d3883e-d7b9-457d-97bd-32fff38c8ba1)
