### PR TITLE
Create zh_cn for 1.20

### DIFF
--- a/common/src/main/resources/assets/moonlight/lang/zh_cn.json
+++ b/common/src/main/resources/assets/moonlight/lang/zh_cn.json
@@ -1,0 +1,8 @@
+{
+  "fluid.moonlight.generic_fluid": "未命名流体",
+  "item.minecraft.potion_lingering": "滞留药水",
+  "item.minecraft.potion_splash": "喷溅药水",
+  "gui.moonlight.open_mod_page": "打开%s的CurseForge页面",
+  "message.moonlight.anti_repost": "你好像从某个奇怪网站下载了%1$s :( 从%2$s下载官方版。",
+  "message.moonlight.anti_repost_link": "这里"
+}


### PR DESCRIPTION
This PR currently contains only non-type-registry keys, further commits would be present if its applicable to move `wood_type`, `leaves_type`, `stone_type`, `mud_type` keys here instead.

Please refer to https://github.com/MehVahdJukaar/StoneZone/pull/67 on this issue.


Forwarding info as tldr maybe:
Only `wood_type` and `leaves_type` would be moved here.