### PR TITLE
Fix fluid stack JSON parsing issue

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/fluids/SoftFluidStack.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/fluids/SoftFluidStack.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 // do NOT have these in a static field as they contain registry holders
 public class SoftFluidStack {
@@ -38,8 +39,8 @@ public class SoftFluidStack {
     public static final Codec<SoftFluidStack> CODEC = RecordCodecBuilder.create(i -> i.group(
             SoftFluid.HOLDER_CODEC.fieldOf("id").forGetter(SoftFluidStack::getHolder),
             Codec.INT.optionalFieldOf("count", 1).forGetter(SoftFluidStack::getCount),
-            CompoundTag.CODEC.optionalFieldOf("tag", null).forGetter(SoftFluidStack::getTag)
-    ).apply(i, SoftFluidStack::of));
+            CompoundTag.CODEC.optionalFieldOf("tag").forGetter(fluidStack -> Optional.ofNullable(fluidStack.getTag()))
+    ).apply(i, SoftFluidStack::fromCodec));
 
     // dont access directly
     private final Holder<SoftFluid> fluidHolder;
@@ -70,6 +71,10 @@ public class SoftFluidStack {
     @Deprecated(forRemoval = true)
     public SoftFluidStack(Holder<SoftFluid> fluid, int count) {
         this(fluid, count, null);
+    }
+
+    private static SoftFluidStack fromCodec(Holder<SoftFluid> fluid, Integer count, Optional<CompoundTag> optionalTag) {
+        return of(fluid, count, optionalTag.orElse(null));
     }
 
     @Deprecated(forRemoval = true)


### PR DESCRIPTION
When Supplementaries loads faucet_interactions data, the following fluid interaction fails to parse:
```json
{
	"target": {
		"predicate_type": "block_match",
		"block": "minecraft:wet_sponge"
	},
	"fluid": {
		"id": "moonlight:water",
		"count": 3
	},
	"replace_with": {
		"Name": "minecraft:sponge"
	}
}
```

Giving the following error: `[14:55:37] [Render thread/ERROR] [Supplementaries/]: Failed to parse JSON object for faucet interaction supplementaries:sponge`, with no further information on the error. (This is also, I believe, the same issue as [this one](https://discord.com/channels/790151253144895508/814403986446221313/1306953367477551215) reported on the Supplementaries Discord server in November.) Interactions that provide items rather than fluids work fine. With a slightly modified jar to add logging the error itself, and printing the stack trace, to the exception-catching on line 73 of FaucetBehaviorsManager.java (currently it only logs errors themselves when they occur during the getOrThrow on line 66; ), I got more information on the error, but not especially helpful information - just that a NullPointerException happened when decoding the Either codec, presumably meaning that it didn't manage to parse this interaction according to either the fluid- or item-interaction codecs, but without saying *why* it failed at trying to parse it as a fluid interaction. The stack trace print is attached for completeness' sake: [stacktrace.txt](https://github.com/user-attachments/files/19639569/stacktrace.txt)

Given that item interactions are parsing as expected, I figured the problem must lie in the differences between the DataItemInteraction and DataFluidInteraction codecs, and in turn the differences between the ItemStack and SoftFluidStack codecs (since the only difference between the interaction codecs is, of course, which stack codec they include).

One of them is that ItemStack.CODEC's id is from the byNameCodec() of the item registry, while SoftFluidStack.CODEC instead references SoftFluid.HOLDER_CODEC. The other is that ItemStack.CODEC's tag field is `optionalFieldOf("tag")` - without a second argument - and its forGetter is a lambda to make an Optional.ofNullable from the item stack's tag. SoftFluidStack.CODEC's tag field is instead `optionalFieldOf("tag", null).forGetter(SoftFluidStack::getTag)` - with a defaultValue argument of null for optionalFieldOf, and calling getTag directly for the forGetter instead of wrapping it in an Optional.ofNullable. Not having nearly enough knowledge of codecs to have any clue where to begin on testing if the issue is with the id field, I went ahead and tried adding `"tag": {}` to the fluid field of my test interaction - and it parsed fine! Even `"tag": null` works (which is nice, as it prevents the annoying issue of e.g. being unable to put water with `tag:{}` into a jar that already has normal water with no tag at all, because the empty tag and the null tag don't match even though from the player's standpoint they're identical).

The existence of this workaround is nice, but given that the tag field is supposed to be optional, the need to define it explicitly still seemed bizarre and presumably not intended behavior, so I decided to try a modified version of Moonlight where FluidStackHolder.CODEC's tag field is edited to be more similar to ItemStack.CODEC's - with the Optional.ofNulalble and the one-argument optionalFieldOf. This also necessitated adding a method that could take the Optional<CompoundTag> in place of the nullable CompoundTag that SoftFluidStack.of currently takes (I considered modifying SoftFluidStack.of to take an Optional instead of a direct CompoundTag, but decided against it to avoid needing all *other* uses of SoftFluidStack.of to update to use Optionals, so I instead threw together this hacky `fromCodec` method that takes an Optional). With this, the no-tag fluid interaction is parsed as expected!

I'm guessing that JSON parsing (at least the way it's implemented in com.mojang.serialization) needs Optionals rather than straight nullables, but NBT can work with nullables fine (hence why there are no similar issues with just loading e.g. serialized block entity data for jars, goblets, or Amendments liquid cauldrons), though I haven't dug into the actual (de)serialization code to check that for sure. Regardless, this fix, while hacky enough to make me feel a little uncomfortable with it, does seem to work without breaking anything else (I've tested saving and loading, with block entities containing soft fluids both with and without tags, to ensure that I haven't inadvertently broken the NBT-based (de)serialization or anything, and that was fine), so I'm going ahead and making this PR for it.