### PR TITLE
Fix #413 and probably other JEI/Creative tab issue

### DIFF
--- a/forge/src/main/java/net/mehvahdjukaar/moonlight/api/platform/forge/RegHelperImpl.java
+++ b/forge/src/main/java/net/mehvahdjukaar/moonlight/api/platform/forge/RegHelperImpl.java
@@ -305,6 +305,8 @@ public class RegHelperImpl {
                         if (after && lastValid != null && !isValid) {
                             var rev = Lists.reverse(new ArrayList<>(items));
                             for (var ni : rev) {
+                                if (lastValid.is(ni.getItem()))
+                                    continue;
                                 entries.putAfter(lastValid, ni, CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
                             }
                             return;


### PR DESCRIPTION
When suppl squared registered the golden candle holder it caused `putAfter` to be called with both the lastValid and ni at the same value causing an Entry in the linkedlist that referenced  and referenced only by itself

Entry that was added using the `put`, like any other mod using accept, would add it to the corrupt part of the list causing it to never be accessed