### PR TITLE
Fix `consistent_entity_renderer_shading` with Gnetum

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/core/mixins/GameRendererMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/core/mixins/GameRendererMixin.java
@@ -10,8 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = GameRenderer.class, priority = 501)
 public abstract class GameRendererMixin {
 
-    @Inject(method = "render", at = @At(value = "NEW",
-            target = "(Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;)Lnet/minecraft/client/gui/GuiGraphics;"))
+    @Inject(method = "render", at = @At(value = "INVOKE",
+            target = "Lcom/mojang/blaze3d/platform/Lighting;setupFor3DItems()V"))
     private void moonlight$messWithEntityRendererLighting(float partialTicks, long nanoTime, boolean renderLevel, CallbackInfo ci) {
         MoonlightClient.beforeRenderGui();
     }


### PR DESCRIPTION
Previously `revertFixedShade` was called at `new GuiGraphics()`, which is *after* the game calls `Lighting.setupFor3DItems()`, leaving the reverted shade not applied. This is fine in vanilla, as the lighting will be applied when rendering hotbar items. However, with Gnetum the hotbar does not render every frame, causing lighting inconsistencies between frames.

The fix is to move the `revertFixedShade` call to *before* `Lighting.setupFor3DItems()`.

Closes #408 