### PR TITLE
Unit Tests for BlockAndItem codec

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,23 +7,17 @@ plugins {
     id("com.possible-triangle.common") apply false
     id("com.possible-triangle.fabric") apply false
     id("com.possible-triangle.neoforge") apply false
-    id("net.mehvahdjukaar.candlelight") version "1.1.6" apply false
+    id("net.mehvahdjukaar.candlelight") version "1.1.8" apply false
     id("dev.mixinmcp.decompile") version "0.9.0" apply false
 }
 
 mod {
-    val mod_description: String by extra
-    val mod_credits: String by extra
-    val mod_license: String by extra
-    val mod_homepage: String by extra
-    val mod_github: String by extra
-    val mod_authors: String by extra
-    additional.add("mod_description", provider { mod_description })
-    additional.add("mod_credits", provider { mod_credits })
-    additional.add("mod_license", provider { mod_license })
-    additional.add("mod_homepage", provider { mod_homepage })
-    additional.add("mod_authors", provider { mod_authors })
-    additional.add("mod_github", provider { mod_github })
+    additional.add("mod_description")
+    additional.add("mod_credits")
+    additional.add("mod_license")
+    additional.add("mod_homepage")
+    additional.add("mod_authors")
+    additional.add("mod_github")
 }
 
 
@@ -35,11 +29,11 @@ subprojects {
     apply(plugin = "maven-publish")
 
     dependencies {
-        compileOnly("net.mehvahdjukaar:candlelight:1.1.6")
+        compileOnly("net.mehvahdjukaar:candlelight:1.1.8")
     }
 
 
-    tasks.withType<GenerateModuleMetadata>().configureEach {
+    tasks.withType<GenerateModuleMetadata> {
         enabled = true
     }
 

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.utils.extendsFrom
+
 plugins {
     id("com.possible-triangle.neoforge")
 }
@@ -14,7 +16,7 @@ neoForge {
 
 dependencies {
     modCompileOnly("curse.maven:irisshaders-455508:5789255")
-    modCompileOnly ("curse.maven:map-atlases-forge-519759:7659933")
+    modCompileOnly("curse.maven:map-atlases-forge-519759:7659933")
     modCompileOnly("curse.maven:modernfix-790626:4599353")
     modCompileOnly("curse.maven:quark-243121:7640331")
 
@@ -31,12 +33,44 @@ dependencies {
 
     // modRuntimeOnly("net.mehvahdjukaar:supplementaries-forge:1.19.2-2.2.3")
     // modRuntimeOnly("net.mehvahdjukaar:supplementaries-neoforge:1.21-3.5.18"){
-    modCompileOnly ("curse.maven:map-atlases-forge-519759:4990003")
+    modCompileOnly("curse.maven:map-atlases-forge-519759:4990003")
     //modImplementation ("curse.maven:supplementaries-412082:4995508")
-    modImplementation ("curse.maven:configured-457570:7122915")
+    modImplementation("curse.maven:configured-457570:7122915")
     modCompileOnly("curse.maven:yacl-667299:5424504")
     modCompileOnly("curse.maven:alexs-caves-924854:4806837")
-
-
 }
 
+// Testing setup, will move this to GradleHelper too on v1.4
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("net.neoforged:testframework:${neoforge.neoforgeVersion.get()}")
+    testImplementation("org.skyscreamer:jsonassert:2.0-rc1")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    enabled = true
+    // mixins are not allowed to be loaded by anything else, not even the test runner
+    exclude("**/mixins/**")
+}
+
+// this is required because I currently disable it in GradleHelper due to weird bugs
+// I will also try to remove it in v1.4, since it's a hack solution for a problem I don't quite understand
+tasks.named<JavaCompile>("compileTestJava") {
+    enabled = true
+}
+
+// this is probably a better solution to the root cause for the weird issue I had above
+configurations {
+    testCompileOnly.extendsFrom(compileOnly)
+}
+
+afterEvaluate {
+    neoForge {
+        unitTest {
+            enable()
+            testedMod = mods[mod.id.get()]
+        }
+    }
+}

--- a/neoforge/src/test/java/net/mehvahdjukaar/moonlight/test/BlockAndItemTest.java
+++ b/neoforge/src/test/java/net/mehvahdjukaar/moonlight/test/BlockAndItemTest.java
@@ -1,0 +1,57 @@
+package net.mehvahdjukaar.moonlight.test;
+
+import com.mojang.serialization.Codec;
+import net.mehvahdjukaar.moonlight.api.misc.BlockAndItem;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+public class BlockAndItemTest extends CodecTest<BlockAndItem> {
+
+    @Override
+    Codec<BlockAndItem> codec() {
+        return BlockAndItem.CODEC;
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEncodingInputs")
+    public void testEncoding(String snapshot, BlockAndItem input) {
+        assertMatchesSnapshot(input, snapshot);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDecodingInputs")
+    public void testDecoding(String snapshot, BlockAndItem expected) {
+        var actual = decodeSnapshot(snapshot);
+        Assertions.assertEquals(expected, actual);
+    }
+
+    public static Stream<Arguments> provideEncodingInputs() {
+        return Stream.of(
+                // This is working
+                Arguments.of("object_both", new BlockAndItem(Blocks.AMETHYST_BLOCK, Items.BUNDLE)),
+                // These two tests are failing
+                Arguments.of("object_item_only", new BlockAndItem(null, Items.BUNDLE)),
+                Arguments.of("object_block_only", new BlockAndItem(Blocks.OBSIDIAN, null))
+        );
+    }
+
+    public static Stream<Arguments> provideDecodingInputs() {
+        return Stream.of(
+                // This is working
+                Arguments.of("object_both", new BlockAndItem(Blocks.AMETHYST_BLOCK, Items.BUNDLE)),
+                Arguments.of("both", new BlockAndItem(Blocks.STONE, Items.STONE)),
+                Arguments.of("block_only", new BlockAndItem(Blocks.LAVA, null)),
+                Arguments.of("item_only", new BlockAndItem(null, Items.BUNDLE)),
+                // These two tests are failing
+                Arguments.of("object_item_only", new BlockAndItem(null, Items.BUNDLE)),
+                Arguments.of("object_block_only", new BlockAndItem(Blocks.OBSIDIAN, null))
+        );
+    }
+
+}

--- a/neoforge/src/test/java/net/mehvahdjukaar/moonlight/test/CodecTest.java
+++ b/neoforge/src/test/java/net/mehvahdjukaar/moonlight/test/CodecTest.java
@@ -1,0 +1,88 @@
+package net.mehvahdjukaar.moonlight.test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.JsonOps;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.server.MinecraftServer;
+import net.neoforged.testframework.junit.EphemeralTestServerProvider;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Objects;
+import java.util.Optional;
+
+@ExtendWith(EphemeralTestServerProvider.class)
+public abstract class CodecTest<T> {
+
+    @Nullable
+    private TestInfo testInfo;
+
+    @Nullable
+    private MinecraftServer server;
+
+    @BeforeEach
+    void init(TestInfo testInfo, MinecraftServer server) {
+        this.testInfo = testInfo;
+        this.server = server;
+    }
+
+    protected MinecraftServer server() {
+        return Objects.requireNonNull(server);
+    }
+
+    protected RegistryOps<JsonElement> jsonOps() {
+        return RegistryOps.create(JsonOps.INSTANCE, server().registryAccess());
+    }
+
+    abstract Codec<T> codec();
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    protected String encodeJson(T input) {
+        var result = codec().encodeStart(jsonOps(), input);
+        Assertions.assertFalse(result.isError(), () -> result.error().get().message());
+        return GSON.toJson(result.getOrThrow());
+    }
+
+    private String loadSnapshot(String name) {
+        var testClass = Optional.ofNullable(testInfo)
+                .flatMap(TestInfo::getTestClass)
+                .orElseThrow();
+        var loader = getClass().getClassLoader();
+        var path = String.join(File.separator, "", "__snapshots__", testClass.getSimpleName(), name);
+
+        try (var stream = loader.getResourceAsStream(path)) {
+            Assertions.assertNotNull(stream, "file not found: " + path);
+            return IOUtils.toString(stream);
+        } catch (IOException e) {
+            throw new RuntimeException("error reading file: " + path);
+        }
+    }
+
+    protected T decodeSnapshot(String name) {
+        var string = loadSnapshot(name + ".json");
+        var json = GSON.fromJson(string, JsonElement.class);
+        var result = codec().parse(jsonOps(), json);
+        Assertions.assertFalse(result.isError(), () -> result.error().get().message());
+        return result.getOrThrow();
+    }
+
+    protected void assertMatchesSnapshot(T actual, String name) {
+        var encoded = encodeJson(actual);
+        var expected = loadSnapshot(name + ".json");
+        JSONAssert.assertEquals(expected, encoded, false);
+    }
+
+}

--- a/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/block_only.json
+++ b/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/block_only.json
@@ -1,0 +1,1 @@
+"minecraft:lava"

--- a/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/both.json
+++ b/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/both.json
@@ -1,0 +1,1 @@
+"minecraft:stone"

--- a/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/item_only.json
+++ b/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/item_only.json
@@ -1,0 +1,1 @@
+"minecraft:bundle"

--- a/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/object_block_only.json
+++ b/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/object_block_only.json
@@ -1,0 +1,3 @@
+{
+  "block": "minecraft:obsidian"
+}

--- a/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/object_both.json
+++ b/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/object_both.json
@@ -1,0 +1,4 @@
+{
+  "block": "minecraft:amethyst_block",
+  "item": "minecraft:bundle"
+}

--- a/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/object_item_only.json
+++ b/neoforge/src/test/resources/__snapshots__/BlockAndItemTest/object_item_only.json
@@ -1,0 +1,3 @@
+{
+  "item": "minecraft:bundle"
+}


### PR DESCRIPTION
- includes an abstract `CodecTest` that can be used for other tests
- lots of boiler-plate stuff in `neoforge/build.gradle.kts`, like commented, I will likely add something in gradle helper v1.4 to set this up using a one-liner
- not all of the tests are currently green, due to the problems I wrote you about