### PR TITLE
Fix `FastSearchPathPackResources.getResource` not returning resources that exist

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/resources/pack/FastSearchPathPackResources.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/resources/pack/FastSearchPathPackResources.java
@@ -104,7 +104,7 @@ public class FastSearchPathPackResources extends AbstractPackResources {
     @Nullable
     public IoSupplier<InputStream> getResource(PackType packType, ResourceLocation location) {
         if (this.packType != packType) return null;
-        if(this.searchTrie.search( location.getNamespace() + "/" + location.getPath()).isEmpty()){
+        if(this.searchTrie.search(ResourceLocationSearchTrie.getResPath(location)).isEmpty()){
             return null;
         }
         Path path = this.root.resolve(packType.getDirectory()).resolve(location.getNamespace());


### PR DESCRIPTION
Context: in https://github.com/embeddedt/ModernFix/issues/656 and https://github.com/embeddedt/ModernFix/issues/657, I received reports that ModernFix's dynamic resources feature does not function correctly with generated assets provided by Moonlight. Dynamic resources uses `getResource` calls under the hood to fetch blockstate/model files one at a time, as opposed to bulk listing them with `listResources` like vanilla does.

I found that `FastSearchPathPackResources.getResource` falsely returns `null` for resources that exist. Upon further investigation, I found that this is because the trie `search` optimization it attempts is incorrect.

In `ResourceLocationSearchTrie` the paths to be inserted are normalized to the containing folder, rather than the exact file. This corresponding normalization is applied in `listResources` by construction, since it takes in a parent path and not an exact filename. However, `getResource` does not take this into account, and directly passes the provided path to the trie without normalizing it first, causing the discrepancy in behavior.

Presumably, the workaround of disabling the cache works because it bypasses this class and the trie entirely, but I didn't investigate further.