### PR TITLE
Update ja_jp.json

### DIFF
--- a/common/src/main/resources/assets/moonlight/lang/ja_jp.json
+++ b/common/src/main/resources/assets/moonlight/lang/ja_jp.json
@@ -460,7 +460,7 @@
   "leaves_type.missingtrees.scots_pine": "アカマツの",
   "leaves_type.missingtrees.swamp_oak": "沼地オークの",
 
-  "wood_type.natures_spirit.aspen": "ポプラの",
+  "wood_type.natures_spirit.aspen": "ヤマナラシの",
   "wood_type.natures_spirit.cedar": "ヒマラヤスギの",
   "wood_type.natures_spirit.coconut": "ココナッツの",
   "wood_type.natures_spirit.cypress": "イトスギの",
@@ -477,7 +477,7 @@
   "wood_type.natures_spirit.sugi": "スギの",
   "wood_type.natures_spirit.willow": "ヤナギの",
   "wood_type.natures_spirit.wisteria": "フジの",
-  "leaves_type.natures_spirit.aspen": "ポプラの",
+  "leaves_type.natures_spirit.aspen": "ヤマナラシの",
   "leaves_type.natures_spirit.blue_wisteria": "青色のフジの",
   "leaves_type.natures_spirit.cedar": "ヒマラヤスギの",
   "leaves_type.natures_spirit.coconut": "ココナッツの",
@@ -505,7 +505,7 @@
   "leaves_type.natures_spirit.white_wisteria": "白色のフジの",
   "leaves_type.natures_spirit.willow": "ヤナギの",
   "leaves_type.natures_spirit.wisteria": "フジの",
-  "leaves_type.natures_spirit.yellow_aspen": "黄色のポプラの",
+  "leaves_type.natures_spirit.yellow_aspen": "黄色のヤマナラシの",
   "leaves_type.natures_spirit.yellow_larch": "黄色のカラマツの",
   "leaves_type.natures_spirit.yellow_maple": "黄色のカエデの",
 

--- a/common/src/main/resources/assets/moonlight/lang/ja_jp.json
+++ b/common/src/main/resources/assets/moonlight/lang/ja_jp.json
@@ -629,11 +629,11 @@
   "leaves_type.undergarden.grongle": "グロングルの",
 
   "wood_type.whisperleaftrees.alder": "ハンノキの",
-  "wood_type.whisperleaftrees.aspen": "アスペンの",
+  "wood_type.whisperleaftrees.aspen": "ヤマナラシの",
   "wood_type.whisperleaftrees.poplar": "ポプラの",
   "wood_type.whisperleaftrees.willow": "ヤナギの",
   "leaves_type.whisperleaftrees.alder": "ハンノキの",
-  "leaves_type.whisperleaftrees.aspen": "アスペンの",
+  "leaves_type.whisperleaftrees.aspen": "ヤマナラシの",
   "leaves_type.whisperleaftrees.poplar": "ポプラの",
   "leaves_type.whisperleaftrees.willow": "ヤナギの",
 


### PR DESCRIPTION
Ahead of the addition of ‘Poplar’ in version 26.3, we have changed the term ‘ポプラ’—which overlaps with this translation—to ‘ヤマナラシ’.