### PR TITLE
Expose missing translation data to config holder

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/platform/configs/ConfigBuilder.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/platform/configs/ConfigBuilder.java
@@ -108,12 +108,19 @@ public abstract class ConfigBuilder {
         Moonlight.addDependent(name.getNamespace());
     }
 
-    public final ModConfigHolder build() {
+    public final ModConfigHolder build(boolean collectTranslations) {
         flushPendingComment(); // a trailing after-comment has no define to claim it
         ModConfigHolder holder = buildHolder();
         holder.setFeatureToggles(getFeatureToggles());
+        if (collectTranslations) {
+            holder.setTranslationMap(translations, moonlightNames);
+        }
         ConfigLangExporter.exportInDev(name.getNamespace(), translations, moonlightNames);
         return holder;
+    }
+
+    public final ModConfigHolder build() {
+        return build(false);
     }
 
     private static String moonlightNamedKey(String name) {

--- a/common/src/main/java/net/mehvahdjukaar/moonlight/api/platform/configs/ModConfigHolder.java
+++ b/common/src/main/java/net/mehvahdjukaar/moonlight/api/platform/configs/ModConfigHolder.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -72,6 +73,7 @@ public abstract class ModConfigHolder {
     private final Runnable changeCallback;
     // short name and full dotted path -> effective enabled supplier, filled in by the builder at build()
     private Map<String, Supplier<Boolean>> featureToggles = Map.of();
+    private Map<String, String> missingTranslations = new LinkedHashMap<>();
 
     protected ModConfigHolder(ResourceLocation id, String fileExtension, Path configDirectory, ConfigType type, @Nullable Runnable changeCallback) {
         this(id, fileExtension, configDirectory, type, changeCallback, true);
@@ -106,6 +108,21 @@ public abstract class ModConfigHolder {
 
     public Map<String, Supplier<Boolean>> getFeatureToggles() {
         return this.featureToggles;
+    }
+
+    @ApiStatus.Internal
+    public void setTranslationMap(Map<String, String> translations, Map<String, String> alreadyTranslated) {
+        translations.forEach((key, name) -> {
+            if (!alreadyTranslated.containsKey(key)) this.missingTranslations.put(key, name);
+        });
+    }
+
+    public boolean hasMissingTranslations() {
+        return !this.missingTranslations.isEmpty();
+    }
+
+    public Map<String, String> getMissingTranslations() {
+        return this.missingTranslations;
     }
 
     protected void onRefresh() {


### PR DESCRIPTION
I basically just save the missing translations, that are usually just used for the ConfigLangExporter, to the config holder. This way the data can easily be used in other areas of the code (e.g. datagen). The names moonlight makes up are removed (similar to ConfigLangExporter).
I made this optional, so you don't save unnecessary data when you want to use the auto generation.

If you'd rather have this implemented differently, or don't want it at all, lemme know ^^